### PR TITLE
unbreak build + release PDF on tag pushes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           cd src
           make
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          echo "pdfFilename=$GITHUB_WORKSPACE/$TAG_NAME.pdf" >> "$GITHUB_OUTPUT"
+          echo "pdfFilename=$GITHUB_WORKSPACE/src/$TAG_NAME.pdf" >> "$GITHUB_OUTPUT"
           mv -v ts.pdf "$TAG_NAME.pdf" && stat "$TAG_NAME.pdf" && realpath "$TAG_NAME.pdf"
 
       - name: Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           cd src
           make
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          echo "pdfFilename=$TAG_NAME.pdf" >> "$GITHUB_OUTPUT"
+          echo "pdfFilename=$GITHUB_WORKSPACE/$TAG_NAME.pdf" >> "$GITHUB_OUTPUT"
           mv -v ts.pdf "$TAG_NAME.pdf" && stat "$TAG_NAME.pdf" && realpath "$TAG_NAME.pdf"
 
       - name: Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Verify Tag is on Main Branch
         id: verify_tag

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,16 @@ jobs:
         with:
           submodules: true
 
+      - name: Verify Tag is on Main Branch
+        id: verify_tag
+        run: |
+          TAG_COMMIT=$(git rev-list -n 1 ${GITHUB_REF})
+          if git merge-base --is-ancestor $TAG_COMMIT origin/main; then
+            echo "on_main=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "on_main=false" >>"$GITHUB_OUTPUT"
+          fi
+
       - name: Build
         id: build_step
         run: |
@@ -30,7 +40,9 @@ jobs:
           mv ts.pdf "${TAG_NAME}.pdf"
 
       - name: Release
-        if: github.base_ref == 'main' && steps.build_step.outcome == 'success'
+        if: >
+          steps.verify_tag.outputs.on_main == 'true' &&
+          steps.build_step.outcome == 'success'
         uses: ncipollo/release-action@v1
         with:
           artifacts: '${{ steps.build_step.outputs.pdfFilename }}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
           make
           TAG_NAME=${GITHUB_REF#refs/tags/}
           echo "pdfFilename=$TAG_NAME.pdf" >> "$GITHUB_OUTPUT"
-          mv ts.pdf "${TAG_NAME}.pdf"
+          mv -v ts.pdf "$TAG_NAME.pdf" && stat "$TAG_NAME.pdf" && realpath "$TAG_NAME.pdf"
 
       - name: Release
         if: >

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install --no-install-recommends -y texlive-latex-extra make
+          sudo apt install -y texlive-latex-extra make
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           cd src
           make
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          echo "pdfFilename=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "pdfFilename=$TAG_NAME.pdf" >> "$GITHUB_OUTPUT"
           mv ts.pdf "${TAG_NAME}.pdf"
 
       - name: Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+---
+name: Build tagged version
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends -y texlive-latex-extra make
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build
+        id: build_step
+        run: |
+          cd src
+          make
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          echo "pdfFilename=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          mv ts.pdf "${TAG_NAME}.pdf"
+
+      - name: Release
+        if: github.base_ref == 'main' && steps.build_step.outcome == 'success'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: '${{ steps.build_step.outputs.pdfFilename }}'
+          generateReleaseNotes: true
+          artifactContentType: 'application/pdf'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/external/listings"]
+	path = src/external/listings
+	url = git://git.gnu.org.ua/listings.git

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,7 @@
 
 FIGURES = $(patsubst %.dot,%.pdf,$(wildcard *.dot))
 
-TSPDF:
-	TEXINPUTS=./external/listings//: pdflatex ts.tex | grep -v "^Overfull"
+TSPDF = TEXINPUTS=./external/listings//: pdflatex ts.tex | grep -v "^Overfull"
 
 default: rebuild
 
@@ -25,6 +24,8 @@ refresh:
 	$(TSPDF)
 
 rebuild:
+	test -d ../.git && git submodule update --init --recursive
+	make -C ./external/listings
 	$(TSPDF)
 	$(TSPDF)
 	$(TSPDF)

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,8 @@
 
 FIGURES = $(patsubst %.dot,%.pdf,$(wildcard *.dot))
 
-TSPDF = pdflatex ts | grep -v "^Overfull"
+TSPDF:
+	TEXINPUTS=./external/listings//: pdflatex ts.tex | grep -v "^Overfull"
 
 default: rebuild
 

--- a/src/macros.tex
+++ b/src/macros.tex
@@ -78,7 +78,9 @@
 % Set the xref label for a clause to be "Clause n", not just "n".
 \makeatletter
 \newcommand{\customlabel}[2]{%
-\@bsphack \begingroup \protected@edef \@currentlabel {\protect \M@TitleReference{#2}{\M@currentTitle}}\MNR@label{#1}\endgroup \@esphack%
+  \@bsphack
+  \protected@write\@auxout{}{\string\newlabel{#1}{{#2}{\thepage}}}%
+  \@esphack
 }
 \makeatother
 \newcommand{\clauselabel}[1]{\customlabel{#1}{Clause \thechapter}}

--- a/src/ts.tex
+++ b/src/ts.tex
@@ -10,7 +10,7 @@
 \usepackage[iso,american]
            {isodate}      % use iso format for dates
 \usepackage[final]
-           {listings}     % code listings
+           {./external/listings/listings}     % code listings
 \usepackage{longtable}    % auto-breaking tables
 \usepackage{ltcaption}    % fix captions for long tables
 \usepackage{relsize}      % provide relative font size changes


### PR DESCRIPTION
 - pulls in 'listings' from [git upstream](https://git.gnu.org.ua/listings.git) and pins it a v1.8d (the latest suported in src/styles.tex)
 - redefine macro `\customlabel` without `\M@TitleReference` and such since those have been long been removed from memoir
 - builds PDFs on git tag pushes to branch main and [publishes them](https://github.com/ebenali/concurrency-ts2/releases/tag/20240309)

the github action was particularly finnicky fine-tuning